### PR TITLE
修复更改图像时，个人详情页的头像不变的问题

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -292,9 +292,11 @@ void Application::onAvatar(const QPixmap &pixmap) {
 void Application::on_logout(const QString &profile)
 {
     qDebug() << __func__<<profile;
-    doLogout();
-    QThread::currentThread()->sleep(1);
+     doLogout();
+    QThread::currentThread()->msleep(100);
     createLoginUI(false);
+   
+    
 }
 
 void Application::on_exit(const QString &profile)

--- a/src/modules/im/src/widget/form/profileform.cpp
+++ b/src/modules/im/src/widget/form/profileform.cpp
@@ -314,8 +314,11 @@ void ProfileForm::onAvatarClicked()
     if (path.isEmpty()) {
         return;
     }
+    
     const IProfileInfo::SetAvatarResult result = profileInfo->setAvatar(path);
-    if (result == IProfileInfo::SetAvatarResult::OK) {     
+    if (result == IProfileInfo::SetAvatarResult::OK) {   
+        qDebug()<<__func__<<"result:"<<(int)result;
+        profilePicture->setPixmap(profileInfo->getAvatar());  
         return;
     }
 

--- a/src/modules/im/src/widget/form/profileform.cpp
+++ b/src/modules/im/src/widget/form/profileform.cpp
@@ -171,7 +171,8 @@ ProfileForm::ProfileForm(IProfileInfo* profileInfo, QWidget* parent)
         cb->installEventFilter(this);
         cb->setFocusPolicy(Qt::StrongFocus);
     }
-
+    connect(Nexus::getProfile(),&Profile::selfAvatarChanged,this,&ProfileForm::onSelfAvatarLoaded);
+    
     retranslateUi();
     settings::Translator::registerHandler(std::bind(&ProfileForm::retranslateUi, this), this);
 }
@@ -317,8 +318,7 @@ void ProfileForm::onAvatarClicked()
     
     const IProfileInfo::SetAvatarResult result = profileInfo->setAvatar(path);
     if (result == IProfileInfo::SetAvatarResult::OK) {   
-        qDebug()<<__func__<<"result:"<<(int)result;
-        profilePicture->setPixmap(profileInfo->getAvatar());  
+        
         return;
     }
 


### PR DESCRIPTION
在设置头像接口调用成功之后，直接修改点击窗口的图片